### PR TITLE
Better cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/jlowellwofford/go-fork v0.1.0
 	github.com/jlowellwofford/uinit v0.1.0
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/net v0.0.0-20210226101413-39120d07d75e
 	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073
 )

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -326,6 +328,7 @@ golang.org/x/sys v0.0.0-20190419153524-e8e3143a4f4a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=

--- a/internal/api/init.go
+++ b/internal/api/init.go
@@ -12,7 +12,7 @@ var Containers ContainersType
 
 const mountDir = "/var/run/imageapi/mounts"
 const logDir = "/var/run/imageapi/logs"
-const collectTime = time.Second * 2
+const collectTime = time.Second * 1
 
 var ERRNOTFOUND = errors.New("not found")
 

--- a/internal/api/init.go
+++ b/internal/api/init.go
@@ -7,10 +7,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var Rbds RbdsType
-var MountsRbd MountsRBDType
-var MountsOverlay MountsOverlayType
-var Containers ContainersType
+var Rbds *RbdsType
+var MountsRbd *MountsRBDType
+var MountsOverlay *MountsOverlayType
+var Containers *ContainersType
 var Log *logrus.Logger
 
 const mountDir = "/var/run/imageapi/mounts"
@@ -33,13 +33,13 @@ func init() {
 	// fixme: read from os.Env?
 	Log.Level = logrus.TraceLevel
 	Log.Info("initializing imageapi-server")
-	Rbds = RbdsType{}
+	Rbds = &RbdsType{}
 	Rbds.Init()
-	MountsRbd = MountsRBDType{}
+	MountsRbd = &MountsRBDType{}
 	MountsRbd.Init()
-	MountsOverlay = MountsOverlayType{}
+	MountsOverlay = &MountsOverlayType{}
 	MountsOverlay.Init()
-	Containers = ContainersType{}
+	Containers = &ContainersType{}
 	Containers.Init()
 	Log.WithField("collectTime", collectTime).Debug("starting garbage collection")
 	go garbageCollect()

--- a/internal/api/init.go
+++ b/internal/api/init.go
@@ -1,6 +1,9 @@
 package api
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
 var Rbds RbdsType
 var MountsRbd MountsRBDType
@@ -9,8 +12,18 @@ var Containers ContainersType
 
 const mountDir = "/var/run/imageapi/mounts"
 const logDir = "/var/run/imageapi/logs"
+const collectTime = time.Second * 2
 
 var ERRNOTFOUND = errors.New("not found")
+
+func garbageCollect() {
+	for {
+		time.Sleep(collectTime)
+		MountsOverlay.Collect()
+		MountsRbd.Collect()
+		Rbds.Collect()
+	}
+}
 
 func init() {
 	Rbds = RbdsType{}
@@ -21,4 +34,5 @@ func init() {
 	MountsOverlay.Init()
 	Containers = ContainersType{}
 	Containers.Init()
+	go garbageCollect()
 }

--- a/internal/api/init.go
+++ b/internal/api/init.go
@@ -3,12 +3,15 @@ package api
 import (
 	"errors"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 var Rbds RbdsType
 var MountsRbd MountsRBDType
 var MountsOverlay MountsOverlayType
 var Containers ContainersType
+var Log *logrus.Logger
 
 const mountDir = "/var/run/imageapi/mounts"
 const logDir = "/var/run/imageapi/logs"
@@ -26,6 +29,10 @@ func garbageCollect() {
 }
 
 func init() {
+	Log = logrus.New()
+	// fixme: read from os.Env?
+	Log.Level = logrus.TraceLevel
+	Log.Info("initializing imageapi-server")
 	Rbds = RbdsType{}
 	Rbds.Init()
 	MountsRbd = MountsRBDType{}
@@ -34,5 +41,6 @@ func init() {
 	MountsOverlay.Init()
 	Containers = ContainersType{}
 	Containers.Init()
+	Log.WithField("collectTime", collectTime).Debug("starting garbage collection")
 	go garbageCollect()
 }

--- a/internal/api/mount.go
+++ b/internal/api/mount.go
@@ -123,13 +123,16 @@ func MountGetMountpoint(mnt *models.Mount) (mntpt string, err error) {
 }
 
 func MountRefAdd(mnt *models.Mount, n int64) {
-	if mnt.MountID == 0 { // we only support doing this by MountID, but we silently fail
-		return
-	}
 	switch *mnt.Kind {
 	case "rbd":
+		if mnt.MountID == 0 {
+			mnt.MountID = mnt.Rbd.ID
+		}
 		MountsRbd.RefAdd(mnt.MountID, n)
 	case "overlay":
+		if mnt.MountID == 0 {
+			mnt.MountID = mnt.Overlay.ID
+		}
 		MountsOverlay.RefAdd(mnt.MountID, n)
 	}
 }

--- a/internal/api/mount_overlay.go
+++ b/internal/api/mount_overlay.go
@@ -9,39 +9,51 @@ import (
 
 	"github.com/bensallen/rbd/pkg/mount"
 	"github.com/jlowellwofford/imageapi/models"
+	"github.com/sirupsen/logrus"
 )
 
 type MountsOverlayType struct {
 	next  models.ID
 	mnts  map[models.ID]*models.MountOverlay
 	mutex *sync.Mutex
+	log   *logrus.Entry
 }
 
 func (m *MountsOverlayType) Init() {
 	m.next = 1 // 0 == unspecified
 	m.mnts = make(map[models.ID]*models.MountOverlay)
 	m.mutex = &sync.Mutex{}
+	m.log = Log.WithField("subsys", "mount_overlay")
 }
 
 func (m *MountsOverlayType) List() (r []*models.MountOverlay) {
+	l := m.log.WithField("operation", "list")
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	for _, mnt := range m.mnts {
 		r = append(r, mnt)
 	}
+	l.WithField("entries", len(r)).Trace("listing entries")
 	return
 }
 
 func (m *MountsOverlayType) Get(id models.ID) (*models.MountOverlay, error) {
+	l := m.log.WithFields(logrus.Fields{
+		"operation": "get",
+		"id":        id,
+	})
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	if r, ok := m.mnts[id]; ok {
+		l.Trace("found")
 		return r, nil
 	}
+	l.Trace("not found")
 	return nil, ERRNOTFOUND
 }
 
 func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOverlay, err error) {
+	l := m.log.WithField("operation", "mount")
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -49,6 +61,7 @@ func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOver
 
 	// there most be at least one lower
 	if len(mnt.Lower) == 0 {
+		l.Debug("no lower mount(s) specified")
 		return nil, fmt.Errorf("at least one lower mount must be specified")
 	}
 
@@ -59,6 +72,11 @@ func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOver
 	for i := range mnt.Lower {
 		if mnt.Lower[i].MountID == 0 { // try to mount
 			if mnt.Lower[i], err = Mount(mnt.Lower[i]); err != nil {
+				// clear refs for mounts we already processed
+				for j := 0; j < i; j++ {
+					MountRefAdd(mnt.Lower[i], -1)
+				}
+				l.WithField("err", err).Error("lower mount failed")
 				return nil, fmt.Errorf("failed to mount lower mount: %v", err)
 			}
 		} else {
@@ -66,6 +84,11 @@ func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOver
 		}
 		var mntpt string
 		if mntpt, err = MountGetMountpoint(mnt.Lower[i]); err != nil {
+			// this means that the mount doesn't exist...
+			for j := 0; j < i; j++ {
+				MountRefAdd(mnt.Lower[i], -1)
+			}
+			l.WithField("err", err).Error("failed to get mountpoint for lower mount")
 			return nil, fmt.Errorf("failed to get mountpoint for lower mount: %v", err)
 		}
 		lmnts = append(lmnts, mntpt)
@@ -81,17 +104,21 @@ func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOver
 	// ok, we're good to attempt the mount
 	// make a mountpoint/upperdir/workdir
 	if err = os.MkdirAll(mountDir, 0700); err != nil {
+		l.WithField("err", err).Error("could not create base directory")
 		return nil, fmt.Errorf("could not create base mount directory: %v", err)
 	}
 	if mnt.Mountpoint, err = ioutil.TempDir(mountDir, "mount_"); err != nil {
+		l.WithField("err", err).Error("could not create mountpoint")
 		return nil, fmt.Errorf("could not create mountpoint: %v", err)
 	}
 	os.Chmod(mnt.Mountpoint, os.FileMode(0755))
 	if mnt.Upperdir, err = ioutil.TempDir(mountDir, "upper_"); err != nil {
+		l.WithField("err", err).Error("could not create upperdir")
 		return nil, fmt.Errorf("could not create upperdir: %v", err)
 	}
 	os.Chmod(mnt.Upperdir, os.FileMode(0755))
 	if mnt.Workdir, err = ioutil.TempDir(mountDir, "work_"); err != nil {
+		l.WithField("err", err).Error("could not create workdir")
 		return nil, fmt.Errorf("could not create workdir: %v", err)
 	}
 	os.Chmod(mnt.Workdir, os.FileMode(0755))
@@ -102,7 +129,9 @@ func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOver
 		"upperdir=" + mnt.Upperdir,
 		"workdir=" + mnt.Workdir,
 	}
+	l.WithField("opts", opts)
 	if err = mount.Mount("overlay", mnt.Mountpoint, "overlay", opts); err != nil {
+		l.WithField("err", err).Error("mount failed")
 		return nil, fmt.Errorf("mount failure: %v", err)
 	}
 
@@ -111,26 +140,34 @@ func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOver
 	mnt.Refs = 1
 	m.next++
 	m.mnts[mnt.ID] = mnt
+	l.Info("successfully mounted")
 
 	return mnt, nil
 }
 
 func (m *MountsOverlayType) Unmount(id models.ID) (mnt *models.MountOverlay, err error) {
+	l := m.log.WithFields(logrus.Fields{
+		"operation": "unmount",
+		"id":        id,
+	})
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
 	var ok bool
 
 	if mnt, ok = m.mnts[id]; !ok {
+		l.Debug("mount does not exist")
 		return nil, ERRNOTFOUND
 	}
 
-	if mnt.Refs > 1 {
+	if mnt.Refs > 0 {
+		l.WithField("refs", mnt.Refs).Debug("nonzero refcount")
 		return nil, fmt.Errorf("unmount failure: mount is in use")
 	}
 
 	// always lazy unmount.  Good idea?
 	if err = mount.Unmount(mnt.Mountpoint, false, true); err != nil {
+		l.WithField("err", err).Error("unmount failed")
 		return nil, fmt.Errorf("unmount failure: %v", err)
 	}
 
@@ -142,29 +179,38 @@ func (m *MountsOverlayType) Unmount(id models.ID) (mnt *models.MountOverlay, err
 		MountRefAdd(l, -1)
 		// garbage collection will handle cleanup
 	}
+	l.Info("successfully unmounted")
 	return
 }
 
 func (m *MountsOverlayType) RefAdd(id models.ID, n int64) {
+	l := m.log.WithField("operation", "refadd")
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	if r, ok := m.mnts[id]; ok {
+		l.WithField("n", n).Trace("added")
 		r.Refs += n
+	} else {
+		l.Debug("no such rbd")
 	}
 }
 
 // Collect will run garbage collection on any RBDs with ref == 0
 func (m *MountsOverlayType) Collect() {
+	l := m.log.WithField("operation", "collect")
 	list := []models.ID{}
 	m.mutex.Lock()
 	for _, mnt := range m.mnts {
-		if mnt.Refs == 0 {
+		if mnt.Refs <= 0 {
 			// let's collect
 			list = append(list, mnt.ID)
 		}
 	}
 	m.mutex.Unlock()
-	for _, id := range list {
-		m.Unmount(id)
+	if len(list) > 0 {
+		l.WithField("collectIDs", list).Debug("collecting")
+		for _, id := range list {
+			m.Unmount(id)
+		}
 	}
 }

--- a/internal/api/mount_overlay.go
+++ b/internal/api/mount_overlay.go
@@ -24,6 +24,7 @@ func (m *MountsOverlayType) Init() {
 	m.mnts = make(map[models.ID]*models.MountOverlay)
 	m.mutex = &sync.Mutex{}
 	m.log = Log.WithField("subsys", "mount_overlay")
+	m.log.Trace("initialized")
 }
 
 func (m *MountsOverlayType) List() (r []*models.MountOverlay) {
@@ -76,7 +77,7 @@ func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOver
 				for j := 0; j < i; j++ {
 					MountRefAdd(mnt.Lower[i], -1)
 				}
-				l.WithField("err", err).Error("lower mount failed")
+				l.WithError(err).Error("lower mount failed")
 				return nil, fmt.Errorf("failed to mount lower mount: %v", err)
 			}
 		} else {
@@ -88,7 +89,7 @@ func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOver
 			for j := 0; j < i; j++ {
 				MountRefAdd(mnt.Lower[i], -1)
 			}
-			l.WithField("err", err).Error("failed to get mountpoint for lower mount")
+			l.WithError(err).Error("failed to get mountpoint for lower mount")
 			return nil, fmt.Errorf("failed to get mountpoint for lower mount: %v", err)
 		}
 		lmnts = append(lmnts, mntpt)
@@ -104,21 +105,21 @@ func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOver
 	// ok, we're good to attempt the mount
 	// make a mountpoint/upperdir/workdir
 	if err = os.MkdirAll(mountDir, 0700); err != nil {
-		l.WithField("err", err).Error("could not create base directory")
+		l.WithError(err).Error("could not create base directory")
 		return nil, fmt.Errorf("could not create base mount directory: %v", err)
 	}
 	if mnt.Mountpoint, err = ioutil.TempDir(mountDir, "mount_"); err != nil {
-		l.WithField("err", err).Error("could not create mountpoint")
+		l.WithError(err).Error("could not create mountpoint")
 		return nil, fmt.Errorf("could not create mountpoint: %v", err)
 	}
 	os.Chmod(mnt.Mountpoint, os.FileMode(0755))
 	if mnt.Upperdir, err = ioutil.TempDir(mountDir, "upper_"); err != nil {
-		l.WithField("err", err).Error("could not create upperdir")
+		l.WithError(err).Error("could not create upperdir")
 		return nil, fmt.Errorf("could not create upperdir: %v", err)
 	}
 	os.Chmod(mnt.Upperdir, os.FileMode(0755))
 	if mnt.Workdir, err = ioutil.TempDir(mountDir, "work_"); err != nil {
-		l.WithField("err", err).Error("could not create workdir")
+		l.WithError(err).Error("could not create workdir")
 		return nil, fmt.Errorf("could not create workdir: %v", err)
 	}
 	os.Chmod(mnt.Workdir, os.FileMode(0755))
@@ -131,7 +132,7 @@ func (m *MountsOverlayType) Mount(mnt *models.MountOverlay) (r *models.MountOver
 	}
 	l.WithField("opts", opts)
 	if err = mount.Mount("overlay", mnt.Mountpoint, "overlay", opts); err != nil {
-		l.WithField("err", err).Error("mount failed")
+		l.WithError(err).Error("mount failed")
 		return nil, fmt.Errorf("mount failure: %v", err)
 	}
 
@@ -167,7 +168,7 @@ func (m *MountsOverlayType) Unmount(id models.ID) (mnt *models.MountOverlay, err
 
 	// always lazy unmount.  Good idea?
 	if err = mount.Unmount(mnt.Mountpoint, false, true); err != nil {
-		l.WithField("err", err).Error("unmount failed")
+		l.WithError(err).Error("unmount failed")
 		return nil, fmt.Errorf("unmount failure: %v", err)
 	}
 

--- a/internal/api/mount_rbd.go
+++ b/internal/api/mount_rbd.go
@@ -8,40 +8,49 @@ import (
 
 	"github.com/bensallen/rbd/pkg/mount"
 	"github.com/jlowellwofford/imageapi/models"
+	"github.com/sirupsen/logrus"
 )
 
 type MountsRBDType struct {
 	next  models.ID
 	mnts  map[models.ID]*models.MountRbd
 	mutex *sync.Mutex
+	log   *logrus.Entry
 }
 
 func (m *MountsRBDType) Init() {
 	m.next = 1 // 0 == unspecified
 	m.mnts = make(map[models.ID]*models.MountRbd)
 	m.mutex = &sync.Mutex{}
+	m.log = Log.WithField("subsys", "mount_rbd")
+	m.log.Trace("initialized")
 }
 
 func (m *MountsRBDType) Mount(mnt *models.MountRbd) (ret *models.MountRbd, err error) {
+	l := m.log.WithField("operation", "mount")
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	// does the mount already exist?
 	if _, ok := m.mnts[mnt.ID]; ok {
+		l.Debug("requested mount of already existing mount")
 		return nil, fmt.Errorf("mount failure: moint already exists: %d", mnt.ID)
 	}
 	// make sure the dev exists, or attach it
 	var rbd *models.Rbd
 	if mnt.RbdID != 0 { // Rbd was specified by ID
 		if rbd, err = Rbds.Get(mnt.RbdID); err != nil {
+			l.WithError(err).Debug("rbd does not exist")
 			return nil, ERRNOTFOUND
 		}
 		Rbds.RefAdd(rbd.ID, 1)
 	} else if mnt.Rbd != nil { // try to attach it
 		if rbd, err = Rbds.Map(mnt.Rbd); err != nil {
+			l.WithError(err).Error("rbd map failed")
 			return nil, fmt.Errorf("failed to attach underlying RBD image: %v", err)
 		}
 		mnt.RbdID = rbd.ID
 	} else { // unspecified
+		l.Error("no rbd specified")
 		return nil, fmt.Errorf("no rbd specified")
 	}
 	defer func() {
@@ -49,25 +58,35 @@ func (m *MountsRBDType) Mount(mnt *models.MountRbd) (ret *models.MountRbd, err e
 			Rbds.RefAdd(rbd.ID, -1)
 		}
 	}()
+	l.WithField("rbd", rbd.ID)
+	// HERE!!!!
 	// ok, we're good to attempt the mount
 	// make a mountpoint
 	if err = os.MkdirAll(mountDir, 0700); err != nil {
+		l.WithError(err).Error("failed to make mount directory")
 		return nil, fmt.Errorf("could not create base mount directory: %v", err)
 	}
 	if mnt.Mountpoint, err = ioutil.TempDir(mountDir, "mount_"); err != nil {
+		l.WithError(err).Error("failed to make pointpoint")
 		return nil, fmt.Errorf("could not create mountpoint: %v", err)
 	}
 	if err = mount.Mount(rbd.DeviceFile, mnt.Mountpoint, *mnt.FsType, mnt.MountOptions); err != nil {
+		l.WithError(err).Error("failed to mount")
 		return nil, fmt.Errorf("mount failure: %v", err)
 	}
 	mnt.ID = m.next
 	mnt.Refs = 1
 	m.next++
 	m.mnts[mnt.ID] = mnt
+	l.Info("successfully mounted")
 	return mnt, nil
 }
 
 func (m *MountsRBDType) Unmount(id models.ID) (ret *models.MountRbd, err error) {
+	l := m.log.WithFields(logrus.Fields{
+		"operation": "unmount",
+		"id":        id,
+	})
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -75,51 +94,68 @@ func (m *MountsRBDType) Unmount(id models.ID) (ret *models.MountRbd, err error) 
 	var ok bool
 
 	if mnt, ok = m.mnts[id]; !ok {
+		l.Debug("mount does not exists")
 		return nil, ERRNOTFOUND
 	}
 
 	if mnt.Refs > 0 {
+		l.WithField("refs", mnt.Refs).Debug("nonzero refcount")
 		return nil, fmt.Errorf("unmount failure: mount is in use")
 	}
 
 	// always lazy unmount.  Good idea?
 	if err = mount.Unmount(mnt.Mountpoint, false, true); err != nil {
+		l.WithError(err).Error("unmount failed")
 		return nil, fmt.Errorf("unmount failure: %v", err)
 	}
 	os.Remove(mnt.Mountpoint) // we shouldn't fail on this. Should we report it anyway?
 	delete(m.mnts, id)
 	Rbds.RefAdd(mnt.RbdID, -1)
+	l.Info("successfully unmounted")
 	// garbage collection should do our cleanup
 	return
 }
 
 func (m *MountsRBDType) Get(id models.ID) (mnt *models.MountRbd, err error) {
+	l := m.log.WithFields(logrus.Fields{
+		"operation": "get",
+		"id":        id,
+	})
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	var ok bool
 	if mnt, ok = m.mnts[id]; !ok {
+		l.Trace("found")
 		return nil, ERRNOTFOUND
 	}
+	l.Trace("not found")
 	return
 }
 
 func (m *MountsRBDType) List() (mnts []*models.MountRbd) {
+	l := m.log.WithField("operation", "list")
 	for _, i := range m.mnts {
 		mnts = append(mnts, i)
 	}
+	l.WithField("entries", len(mnts)).Trace("listing entries")
 	return
 }
 
 func (m *MountsRBDType) RefAdd(id models.ID, n int64) {
+	l := m.log.WithField("operation", "refadd")
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	if mnt, ok := m.mnts[id]; ok {
+		l.WithField("n", n).Trace("added")
 		mnt.Refs += n
+	} else {
+		l.Debug("no such rbd")
 	}
 }
 
 // Collect will run garbage collection on any RBDs with ref == 0
 func (m *MountsRBDType) Collect() {
+	l := m.log.WithField("operation", "collect")
 	list := []models.ID{}
 	m.mutex.Lock()
 	for _, mnt := range m.mnts {
@@ -129,7 +165,10 @@ func (m *MountsRBDType) Collect() {
 		}
 	}
 	m.mutex.Unlock()
-	for _, id := range list {
-		m.Unmount(id)
+	if len(list) > 0 {
+		l.WithField("collectIDs", list).Debug("collecting")
+		for _, id := range list {
+			m.Unmount(id)
+		}
 	}
 }

--- a/internal/api/rbds.go
+++ b/internal/api/rbds.go
@@ -8,26 +8,32 @@ import (
 
 	"github.com/bensallen/rbd/pkg/krbd"
 	"github.com/jlowellwofford/imageapi/models"
+	"github.com/sirupsen/logrus"
 )
 
 type RbdsType struct {
 	next  models.ID
 	rbds  map[models.ID]*models.Rbd
 	mutex *sync.Mutex
+	log   *logrus.Entry
 }
 
 func (r *RbdsType) Init() {
 	r.next = 1 // starting from 1 means 0 == unspecified
 	r.rbds = make(map[models.ID]*models.Rbd)
 	r.mutex = &sync.Mutex{}
+	r.log = Log.WithField("subsys", "rbd")
+	r.log.Trace("initialized")
 }
 
 func (r *RbdsType) List() (result []*models.Rbd) {
+	l := r.log.WithField("operation", "list")
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	for _, m := range r.rbds {
 		result = append(result, m)
 	}
+	l.WithField("entries", len(result)).Trace("listing rbd entries")
 	return
 }
 
@@ -35,11 +41,20 @@ func (r *RbdsType) Map(rbd *models.Rbd) (m *models.Rbd, err error) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	// sanity check
+	l := r.log.WithField("operation", "map")
 	if len(rbd.Monitors) == 0 || *rbd.Pool == "" || *rbd.Image == "" || rbd.Options.Name == "" || rbd.Options.Secret == "" {
+		r.log.Debug("incorrect options")
 		return nil, fmt.Errorf("the following are required: 1 or more monitors, pool, image, options/name, options/secret")
 	}
+	l = l.WithFields(logrus.Fields{
+		"image":    *rbd.Image,
+		"pool":     *rbd.Pool,
+		"name":     rbd.Options.Name,
+		"monitors": rbd.Monitors,
+	})
 	w, err := krbd.RBDBusAddWriter()
 	if err != nil {
+		l.WithField("err", err).Error("failed to get krbd bus writer")
 		return nil, fmt.Errorf("krbd error: %v", err)
 	}
 	defer w.Close()
@@ -66,15 +81,18 @@ func (r *RbdsType) Map(rbd *models.Rbd) (m *models.Rbd, err error) {
 	dev := krbd.Device{Image: i.Image, Pool: i.Pool, Namespace: i.Options.Namespace, Snapshot: i.Snapshot}
 
 	if err := dev.Find(); err == nil {
+		l.Debug("tried to map device that already exists")
 		return nil, fmt.Errorf("rbd device already exists")
 	}
 	// map the rbd
 	if err := i.Map(w); err != nil {
+		l.WithField("err", err).Error("map failed")
 		return nil, fmt.Errorf("krbd error: %v", err)
 	}
 
 	// now go find our ID
 	if err := dev.Find(); err != nil {
+		l.WithField("err", err).Error("mapped device was not found")
 		return nil, fmt.Errorf("could not find device ID: %v", err)
 	}
 	rbd.DeviceID = dev.ID
@@ -83,21 +101,31 @@ func (r *RbdsType) Map(rbd *models.Rbd) (m *models.Rbd, err error) {
 	rbd.Refs = 1
 	r.next++
 	r.rbds[rbd.ID] = rbd
-
+	l.Info("successfully mapped")
 	return rbd, err
 }
 
 func (r *RbdsType) Get(id models.ID) (m *models.Rbd, err error) {
+	l := r.log.WithFields(logrus.Fields{
+		"operation": "get",
+		"id":        id,
+	})
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	var ok bool
 	if m, ok = r.rbds[id]; ok {
+		l.Trace("found")
 		return
 	}
+	l.Trace("not found")
 	return nil, ERRNOTFOUND
 }
 
 func (r *RbdsType) Unmap(id models.ID) (m *models.Rbd, err error) {
+	l := r.log.WithFields(logrus.Fields{
+		"operation": "unmap",
+		"id":        id,
+	})
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -105,16 +133,25 @@ func (r *RbdsType) Unmap(id models.ID) (m *models.Rbd, err error) {
 	var ok bool
 
 	if rbd, ok = r.rbds[id]; !ok {
+		l.Debug("not found")
 		return nil, ERRNOTFOUND
 	}
+	l = l.WithFields(logrus.Fields{
+		"image":    *rbd.Image,
+		"pool":     *rbd.Pool,
+		"name":     rbd.Options.Name,
+		"monitors": rbd.Monitors,
+	})
 
 	// should we be able to force this?
 	if rbd.Refs > 0 {
+		l.WithField("refs", rbd.Refs).Debug("nonzero refcount")
 		return nil, fmt.Errorf("device %d is in use, cannot unmap", id)
 	}
 
 	wc, err := krbd.RBDBusRemoveWriter()
 	if err != nil {
+		l.WithField("err", err).Error("couldn't get remove writer")
 		return nil, err
 	}
 	defer wc.Close()
@@ -127,10 +164,12 @@ func (r *RbdsType) Unmap(id models.ID) (m *models.Rbd, err error) {
 	}
 
 	if err := i.Unmap(wc); err != nil {
+		l.WithField("err", err).Error("unmap failed")
 		return nil, fmt.Errorf("krbd error: %v", err)
 	}
 	// remove from our map
 	delete(r.rbds, id)
+	l.Info("successfully unmapped")
 
 	return rbd, nil
 }
@@ -138,15 +177,20 @@ func (r *RbdsType) Unmap(id models.ID) (m *models.Rbd, err error) {
 // add/subtract from ref counter
 // silently fails if id doesn't exist
 func (r *RbdsType) RefAdd(id models.ID, n int64) {
+	l := r.log.WithField("operation", "refadd")
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	if rbd, ok := r.rbds[id]; ok {
+		l.WithField("n", n).Trace("added")
 		rbd.Refs += n
+	} else {
+		l.Debug("no such rbd")
 	}
 }
 
 // Collect will run garbage collection on any RBDs with ref == 0
 func (r *RbdsType) Collect() {
+	l := r.log.WithField("operation", "collect")
 	list := []models.ID{}
 	r.mutex.Lock()
 	for _, rbd := range r.rbds {
@@ -156,7 +200,10 @@ func (r *RbdsType) Collect() {
 		}
 	}
 	r.mutex.Unlock()
-	for _, id := range list {
-		r.Unmap(id)
+	if len(list) > 0 {
+		l.WithField("collectIDs", list).Debug("collecting")
+		for _, id := range list {
+			r.Unmap(id)
+		}
 	}
 }

--- a/internal/api/rbds.go
+++ b/internal/api/rbds.go
@@ -33,7 +33,7 @@ func (r *RbdsType) List() (result []*models.Rbd) {
 	for _, m := range r.rbds {
 		result = append(result, m)
 	}
-	l.WithField("entries", len(result)).Trace("listing rbd entries")
+	l.WithField("entries", len(result)).Trace("listing entries")
 	return
 }
 
@@ -194,7 +194,7 @@ func (r *RbdsType) Collect() {
 	list := []models.ID{}
 	r.mutex.Lock()
 	for _, rbd := range r.rbds {
-		if rbd.Refs == 0 {
+		if rbd.Refs <= 0 {
 			// let's collect
 			list = append(list, rbd.ID)
 		}

--- a/internal/api/rbds.go
+++ b/internal/api/rbds.go
@@ -54,7 +54,7 @@ func (r *RbdsType) Map(rbd *models.Rbd) (m *models.Rbd, err error) {
 	})
 	w, err := krbd.RBDBusAddWriter()
 	if err != nil {
-		l.WithField("err", err).Error("failed to get krbd bus writer")
+		l.WithError(err).Error("failed to get krbd bus writer")
 		return nil, fmt.Errorf("krbd error: %v", err)
 	}
 	defer w.Close()
@@ -86,13 +86,13 @@ func (r *RbdsType) Map(rbd *models.Rbd) (m *models.Rbd, err error) {
 	}
 	// map the rbd
 	if err := i.Map(w); err != nil {
-		l.WithField("err", err).Error("map failed")
+		l.WithError(err).Error("map failed")
 		return nil, fmt.Errorf("krbd error: %v", err)
 	}
 
 	// now go find our ID
 	if err := dev.Find(); err != nil {
-		l.WithField("err", err).Error("mapped device was not found")
+		l.WithError(err).Error("mapped device was not found")
 		return nil, fmt.Errorf("could not find device ID: %v", err)
 	}
 	rbd.DeviceID = dev.ID
@@ -151,7 +151,7 @@ func (r *RbdsType) Unmap(id models.ID) (m *models.Rbd, err error) {
 
 	wc, err := krbd.RBDBusRemoveWriter()
 	if err != nil {
-		l.WithField("err", err).Error("couldn't get remove writer")
+		l.WithError(err).Error("couldn't get remove writer")
 		return nil, err
 	}
 	defer wc.Close()
@@ -164,7 +164,7 @@ func (r *RbdsType) Unmap(id models.ID) (m *models.Rbd, err error) {
 	}
 
 	if err := i.Unmap(wc); err != nil {
-		l.WithField("err", err).Error("unmap failed")
+		l.WithError(err).Error("unmap failed")
 		return nil, fmt.Errorf("krbd error: %v", err)
 	}
 	// remove from our map

--- a/restapi/configure_imageapi.go
+++ b/restapi/configure_imageapi.go
@@ -57,7 +57,6 @@ func configureAPI(api *operations.ImageapiAPI) http.Handler {
 		if r, err = internal.Rbds.Map(params.Rbd); err != nil {
 			return attach.NewMapRbdDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
 		}
-		internal.Rbds.RefAdd(r.ID, 1)
 		return attach.NewMapRbdCreated().WithPayload(r)
 	})
 
@@ -73,6 +72,7 @@ func configureAPI(api *operations.ImageapiAPI) http.Handler {
 	api.AttachUnmapRbdHandler = attach.UnmapRbdHandlerFunc(func(params attach.UnmapRbdParams) middleware.Responder {
 		var err error
 		var r *models.Rbd
+		internal.Rbds.RefAdd(models.ID(params.ID), -1)
 		if r, err = internal.Rbds.Unmap(models.ID(params.ID)); err != nil {
 			if err == internal.ERRNOTFOUND {
 				return attach.NewUnmapRbdDefault(404).WithPayload(&models.Error{Code: 404, Message: swag.String("rbd not found")})
@@ -94,7 +94,6 @@ func configureAPI(api *operations.ImageapiAPI) http.Handler {
 		if r, err = internal.MountsRbd.Mount(params.Mount); err != nil {
 			return mounts.NewMountRbdDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
 		}
-		internal.MountsRbd.RefAdd(r.ID, 1)
 		return mounts.NewMountRbdCreated().WithPayload(r)
 	})
 
@@ -110,6 +109,7 @@ func configureAPI(api *operations.ImageapiAPI) http.Handler {
 	api.MountsUnmountRbdHandler = mounts.UnmountRbdHandlerFunc(func(params mounts.UnmountRbdParams) middleware.Responder {
 		var err error
 		var r *models.MountRbd
+		internal.MountsRbd.RefAdd(models.ID(params.ID), -1)
 		if r, err = internal.MountsRbd.Unmount(models.ID(params.ID)); err != nil {
 			if err == internal.ERRNOTFOUND {
 				return mounts.NewUnmountRbdDefault(404).WithPayload(&models.Error{Code: 404, Message: swag.String("mount not found")})
@@ -131,7 +131,6 @@ func configureAPI(api *operations.ImageapiAPI) http.Handler {
 		if r, err = internal.MountsOverlay.Mount(params.Mount); err != nil {
 			return mounts.NewMountOverlayDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
 		}
-		internal.MountsOverlay.RefAdd(r.ID, 1)
 		return mounts.NewMountOverlayCreated().WithPayload(r)
 	})
 
@@ -147,6 +146,7 @@ func configureAPI(api *operations.ImageapiAPI) http.Handler {
 	api.MountsUnmountOverlayHandler = mounts.UnmountOverlayHandlerFunc(func(params mounts.UnmountOverlayParams) middleware.Responder {
 		var err error
 		var r *models.MountOverlay
+		internal.MountsOverlay.RefAdd(models.ID(params.ID), -1)
 		if r, err = internal.MountsOverlay.Unmount(models.ID(params.ID)); err != nil {
 			if err == internal.ERRNOTFOUND {
 				return mounts.NewUnmountOverlayDefault(404).WithPayload(&models.Error{Code: 404, Message: swag.String("mount not found")})
@@ -245,6 +245,7 @@ func configureAPI(api *operations.ImageapiAPI) http.Handler {
 	api.MountsDeleteMountHandler = mounts.DeleteMountHandlerFunc(func(params mounts.DeleteMountParams) middleware.Responder {
 		var mnt *models.Mount
 		var err error
+		internal.MountRefAdd(params.Mount, -1)
 		if mnt, err = internal.Unmount(params.Mount); err != nil {
 			return mounts.NewDeleteMountDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
 		}

--- a/restapi/configure_imageapi.go
+++ b/restapi/configure_imageapi.go
@@ -57,6 +57,7 @@ func configureAPI(api *operations.ImageapiAPI) http.Handler {
 		if r, err = internal.Rbds.Map(params.Rbd); err != nil {
 			return attach.NewMapRbdDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
 		}
+		internal.Rbds.RefAdd(r.ID, 1)
 		return attach.NewMapRbdCreated().WithPayload(r)
 	})
 
@@ -93,6 +94,7 @@ func configureAPI(api *operations.ImageapiAPI) http.Handler {
 		if r, err = internal.MountsRbd.Mount(params.Mount); err != nil {
 			return mounts.NewMountRbdDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
 		}
+		internal.MountsRbd.RefAdd(r.ID, 1)
 		return mounts.NewMountRbdCreated().WithPayload(r)
 	})
 
@@ -129,6 +131,7 @@ func configureAPI(api *operations.ImageapiAPI) http.Handler {
 		if r, err = internal.MountsOverlay.Mount(params.Mount); err != nil {
 			return mounts.NewMountOverlayDefault(500).WithPayload(&models.Error{Code: 500, Message: swag.String(err.Error())})
 		}
+		internal.MountsOverlay.RefAdd(r.ID, 1)
 		return mounts.NewMountOverlayCreated().WithPayload(r)
 	})
 


### PR DESCRIPTION
This PR does three primary things:
1) syncs filesystems before declaring a container exited
2) Introduces garbage collection, and uses that for dependent mount cleanup
3) Adds (finally) a bunch of logging messages with different log levels using `logrus`

Resolves  #11 