### PR TITLE
set log level through env vars

### DIFF
--- a/internal/api/init.go
+++ b/internal/api/init.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"os"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -28,10 +29,26 @@ func garbageCollect() {
 	}
 }
 
+var llStringToLL = map[string]logrus.Level{
+	"PANIC": logrus.PanicLevel,
+	"FATAL": logrus.FatalLevel,
+	"ERROR": logrus.ErrorLevel,
+	"WARN":  logrus.WarnLevel,
+	"INFO":  logrus.InfoLevel,
+	"DEBUG": logrus.DebugLevel,
+	"TRACE": logrus.TraceLevel,
+}
+
 func init() {
 	Log = logrus.New()
 	// fixme: read from os.Env?
-	Log.Level = logrus.DebugLevel
+	logLevel := logrus.InfoLevel
+	if val, ok := os.LookupEnv("IMAGEAPI_LOGLEVEL"); ok {
+		if ll, ok := llStringToLL[val]; ok {
+			logLevel = ll
+		}
+	}
+	Log.Level = logLevel
 	Log.Info("initializing imageapi-server")
 	Rbds = &RbdsType{}
 	Rbds.Init()


### PR DESCRIPTION
Setting `IMAGEAPI_LOGLEVEL=<loglevel>` sets the imageapi log level.  Valid values are:
```
PANIC
FATAL
ERROR
WARN
INFO
DEBUG
TRACE
```